### PR TITLE
v2.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "codeinc/psr7-responses",
-  "version": "2.0.0-dev",
+  "version": "2.0.0-beta.1",
   "description": "A collection of PSR-7 responses",
   "homepage": "https://github.com/CodeIncHQ/Psr7Responses",
   "type": "library",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "codeinc/psr7-responses",
-  "version": "1.4.5",
+  "version": "2.0.0-dev",
   "description": "A collection of PSR-7 responses",
   "homepage": "https://github.com/CodeIncHQ/Psr7Responses",
   "type": "library",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "codeinc/psr7-responses",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0",
   "description": "A collection of PSR-7 responses",
   "homepage": "https://github.com/CodeIncHQ/Psr7Responses",
   "type": "library",

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
   "license": "MIT",
   "require": {
     "php": ">=7.1",
+    "ext-json": "*",
     "psr/http-message": "^1.0",
     "guzzlehttp/psr7": "^1.4",
     "codeinc/error-renderer": "^1.1",

--- a/src/CharsetResponseInterface.php
+++ b/src/CharsetResponseInterface.php
@@ -3,53 +3,36 @@
 // +---------------------------------------------------------------------+
 // | CODE INC. SOURCE CODE                                               |
 // +---------------------------------------------------------------------+
-// | Copyright (c) 2017 - Code Inc. SAS - All Rights Reserved.           |
+// | Copyright (c) 2018 - Code Inc. SAS - All Rights Reserved.           |
 // | Visit https://www.codeinc.fr for more information about licensing.  |
 // +---------------------------------------------------------------------+
 // | NOTICE:  All information contained herein is, and remains the       |
 // | property of Code Inc. SAS. The intellectual and technical concepts  |
 // | contained herein are proprietary to Code Inc. SAS are protected by  |
 // | trade secret or copyright law. Dissemination of this information or |
-// | reproduction of this material  is strictly forbidden unless prior   |
+// | reproduction of this material is strictly forbidden unless prior    |
 // | written permission is obtained from Code Inc. SAS.                  |
 // +---------------------------------------------------------------------+
 //
 // Author:   Joan Fabrégat <joan@codeinc.fr>
-// Date:     04/03/2018
-// Time:     11:55
+// Date:     08/10/2018
 // Project:  Psr7Responses
 //
-declare(strict_types = 1);
+declare(strict_types=1);
 namespace CodeInc\Psr7Responses;
-use CodeInc\Psr7Responses\Tests\DebugResponseTest;
-
 
 /**
- * Class DebugResponse
+ * Interface CharsetResponseInterface
  *
- * @see DebugResponseTest
  * @package CodeInc\Psr7Responses
  * @author Joan Fabrégat <joan@codeinc.fr>
- * @license MIT <https://github.com/CodeIncHQ/Psr7Responses/blob/master/LICENSE>
- * @link https://github.com/CodeIncHQ/Psr7Responses
  */
-class DebugResponse extends HtmlResponse
+interface CharsetResponseInterface
 {
-	/**
-	 * DebugResponse constructor.
-	 *
-	 * @param $debugInfos
-	 * @param null|string $charset
-	 * @param int $status
-	 * @param array $headers
-	 * @param string $version
-	 * @param null|string $reason
-	 */
-	public function __construct($debugInfos, ?string $charset = null, int $status = 200, array $headers = [],
-        string $version = '1.1', ?string $reason = null)
-	{
-		ob_start();
-		var_dump($debugInfos);
-		parent::__construct(ob_get_clean(), $charset, $status, $headers, $version, $reason);
-	}
+    /**
+     * Returns the response's charset.
+     *
+     * @return string
+     */
+    public function getCharset():string;
 }

--- a/src/ErrorResponse.php
+++ b/src/ErrorResponse.php
@@ -31,6 +31,9 @@ use CodeInc\Psr7Responses\Tests\ErrorResponseTest;
  * @uses ErrorResponseTest
  * @package CodeInc\Psr7Responses
  * @author Joan Fabrégat <joan@codeinc.fr>
+ * @license MIT <https://github.com/CodeIncHQ/Psr7Responses/blob/master/LICENSE>
+ * @link https://github.com/CodeIncHQ/Psr7Responses
+ * @version 2
  */
 class ErrorResponse extends HtmlResponse
 {
@@ -39,23 +42,29 @@ class ErrorResponse extends HtmlResponse
      */
     private $error;
 
-	/**
-	 * ErrorResponse constructor.
-	 *
-	 * @param \Throwable $error
-	 * @param null|string $charset
-	 * @param int $status
-	 * @param array $headers
-	 * @param string $version
-	 * @param null|string $reason
-	 */
-	public function __construct(\Throwable $error, ?string $charset = null,
-        int $status = 500, array $headers = [], string $version = '1.1',
-        ?string $reason = null)
+    /**
+     * ErrorResponse constructor.
+     *
+     * @param \Throwable $error
+     * @param int $code
+     * @param string $reasonPhrase
+     * @param string $charset
+     * @param array $headers
+     * @param string $version
+     * @throws \ReflectionException
+     */
+	public function __construct(\Throwable $error, int $code = 200, string $reasonPhrase = '',
+        string $charset = 'utf-8', array $headers = [], string $version = '1.1')
 	{
 	    $this->error = $error;
-		parent::__construct((new HtmlErrorRenderer($error))->get(),
-			$charset, $status, $headers, $version, $reason);
+		parent::__construct(
+		    (new HtmlErrorRenderer($error))->get(),
+			$code,
+            $reasonPhrase,
+            $charset,
+            $headers,
+            $version
+        );
 	}
 
     /**

--- a/src/FileResponse.php
+++ b/src/FileResponse.php
@@ -32,27 +32,27 @@ use Psr\Http\Message\StreamInterface;
  * @see FileResponseTest
  * @package CodeInc\Psr7Responses
  * @author Joan Fabrégat <joan@codeinc.fr>
+ * @license MIT <https://github.com/CodeIncHQ/Psr7Responses/blob/master/LICENSE>
+ * @link https://github.com/CodeIncHQ/Psr7Responses
+ * @version 2
  */
 class FileResponse extends StreamResponse
 {
-	public const DEFAULT_MIME_TYPE = 'application/octet-stream';
-
     /**
      * FileResponse constructor.
      *
      * @param string|resource|StreamInterface $file
-     * @param null|string $fileName
+     * @param string $fileName
+     * @param int $code
+     * @param string $reasonPhrase
      * @param null|string $contentType
      * @param bool $asAttachment
-     * @param int $status
      * @param array $headers
      * @param string $version
-     * @param null|string $reason
      * @throws \CodeInc\MediaTypes\Exceptions\MediaTypesException
      */
-	public function __construct($file, string $fileName, ?string $contentType = null,
-		bool $asAttachment = true, int $status = 200, array $headers = [],
-		string $version = '1.1', ?string $reason = null)
+	public function __construct($file, string $fileName, int $code = 200, string $reasonPhrase = '',
+        ?string $contentType = null, bool $asAttachment = true, array $headers = [], string $version = '1.1')
 	{
 	    if (is_string($file)) {
             if (!is_file($file)) {
@@ -75,14 +75,14 @@ class FileResponse extends StreamResponse
 
 		parent::__construct(
 			$stream,
-			$contentType ?? MediaTypes::getFilenameMediaType($fileName, self::DEFAULT_MIME_TYPE),
+			$code,
+			$reasonPhrase,
+			$contentType ?? MediaTypes::getFilenameMediaType($fileName, 'application/octet-stream'),
 			null,
 			$fileName,
 			$asAttachment,
-			$status,
 			$headers,
-			$version,
-			$reason
+			$version
 		);
 	}
 }

--- a/src/ForbiddenResponse.php
+++ b/src/ForbiddenResponse.php
@@ -41,7 +41,7 @@ class ForbiddenResponse extends HtmlResponse
      * @param string $version
      * @param null|string $reason
      */
-	public function __construct(string $html = null, ?string $charset = null, array $headers = [],
+	public function __construct(string $html = null, string $charset = 'utf-8', array $headers = [],
 		$body = null, string $version = '1.1', ?string $reason = null)
 	{
 		parent::__construct($html ?? '', $charset, 403, $headers, $version, $reason);

--- a/src/HtmlResponse.php
+++ b/src/HtmlResponse.php
@@ -31,38 +31,37 @@ use GuzzleHttp\Psr7\Response;
  * @author Joan Fabrégat <joan@codeinc.fr>
  * @license MIT <https://github.com/CodeIncHQ/Psr7Responses/blob/master/LICENSE>
  * @link https://github.com/CodeIncHQ/Psr7Responses
+ * @version 2
  */
-class HtmlResponse extends Response
+class HtmlResponse extends Response implements CharsetResponseInterface
 {
-	public const DEFAULT_CHARSET = "utf-8";
-
     /**
      * @var string
      */
 	private $html;
 
     /**
-     * @var null|string
+     * @var string
      */
 	private $charset;
 
-	/**
-	 * HtmlResponse constructor.
-	 *
-	 * @param string $html
-	 * @param null|string $charset
-	 * @param int $status
-	 * @param array $headers
-	 * @param string $version
-	 * @param null|string $reason
-	 */
-	public function __construct(string $html, ?string $charset = null, int $status = 200, array $headers = [],
-		string $version = '1.1', ?string $reason = null)
+    /**
+     * HtmlResponse constructor.
+     *
+     * @param string $html
+     * @param int $code
+     * @param string $reasonPhrase
+     * @param string $charset
+     * @param array $headers
+     * @param string $version
+     */
+	public function __construct(string $html, int $code = 200, string $reasonPhrase = '',
+        string $charset = 'utf-8', array $headers = [], string $version = '1.1')
 	{
-		$headers["Content-Type"] = "text/html; charset=".($charset ?? self::DEFAULT_CHARSET);
+		$headers['Content-Type'] = sprintf('text/html; charset=%s', $charset);
 		$this->html = $html;
 		$this->charset = $charset;
-		parent::__construct($status, $headers, $html, $version, $reason);
+		parent::__construct($code, $headers, $html, $version, $reasonPhrase);
 	}
 
     /**
@@ -76,9 +75,10 @@ class HtmlResponse extends Response
     }
 
     /**
-     * @return null|string
+     * @inheritdoc
+     * @return string
      */
-    public function getCharset():?string
+    public function getCharset():string
     {
         return $this->charset;
     }

--- a/src/HttpProxyResponse.php
+++ b/src/HttpProxyResponse.php
@@ -35,6 +35,7 @@ use function GuzzleHttp\Psr7\stream_for;
  * @author Joan Fabrégat <joan@codeinc.fr>
  * @license MIT <https://github.com/CodeIncHQ/Psr7Responses/blob/master/LICENSE>
  * @link https://github.com/CodeIncHQ/Psr7Responses
+ * @version 2
  */
 class HttpProxyResponse extends Response
 {
@@ -59,31 +60,13 @@ class HttpProxyResponse extends Response
      * ProxyResponse constructor.
      *
      * @param string $remoteUrl
-     * @param int $status
+     * @param int $code
+     * @param string $reasonPhrase
      * @param array $headers
      * @param string $version
-     * @param null|string $reason
-     * @throws ResponseException
      */
-    public function __construct(string $remoteUrl, int $status = 200, array $headers = [],
-        string $version = '1.1', ?string $reason = null)
-    {
-        $this->setRemoteUrl($remoteUrl);
-
-        parent::__construct(
-            $status,
-            $this->importHttpHeader($headers),
-            $this->getStream(),
-            $version,
-            $reason
-        );
-    }
-
-    /**
-     * @param string $remoteUrl
-     * @throws ResponseException
-     */
-    private function setRemoteUrl(string $remoteUrl):void
+    public function __construct(string $remoteUrl, int $code = 200, string $reasonPhrase = '',
+        array $headers = [], string $version = '1.1')
     {
         if (!filter_var($remoteUrl, FILTER_VALIDATE_URL)) {
             throw new ResponseException(
@@ -92,6 +75,14 @@ class HttpProxyResponse extends Response
             );
         }
         $this->remoteUrl = $remoteUrl;
+
+        parent::__construct(
+            $code,
+            $this->importHttpHeader($headers),
+            $this->getStream(),
+            $version,
+            $reasonPhrase
+        );
     }
 
     /**

--- a/src/JsonResponse.php
+++ b/src/JsonResponse.php
@@ -31,44 +31,42 @@ use GuzzleHttp\Psr7\Response;
  * @author Joan Fabrégat <joan@codeinc.fr>
  * @license MIT <https://github.com/CodeIncHQ/Psr7Responses/blob/master/LICENSE>
  * @link https://github.com/CodeIncHQ/Psr7Responses
+ * @version 2
  */
-class JsonResponse extends Response
+class JsonResponse extends Response implements CharsetResponseInterface
 {
-	public const DEFAULT_CHARSET = "utf-8";
-
     /**
      * @var string
      */
 	private $json;
 
     /**
-     * @var null|string
+     * @var string
      */
 	private $charset;
 
-	/**
-	 * TextResponse constructor.
-	 *
-	 * @param string|array|object $json
-	 * @param int $status
-     * @param string|null $charset
-	 * @param array $headers
-	 * @param string $version
-	 * @param null|string $reason
-	 */
-	public function __construct($json, int $status = 200, ?string $charset = null, array $headers = [],
-		string $version = '1.1', ?string $reason = null)
+    /**
+     * TextResponse constructor.
+     *
+     * @param string $json
+     * @param int $code
+     * @param string $reasonPhrase
+     * @param string $charset
+     * @param array $headers
+     * @param string $version
+     */
+	public function __construct(string $json, int $code = 200, string $reasonPhrase = '',
+        string $charset = 'utf-8', array $headers = [], string $version = '1.1')
 	{
-		if (!is_string($json)) {
-			$json = json_encode($json);
-		}
 		$this->json = $json;
 		$this->charset = $charset;
-		$headers["Content-Type"] = "application/json; charset=".($charset ?? self::DEFAULT_CHARSET);
-		parent::__construct($status, $headers, $json, $version, $reason);
+		$headers['Content-Type'] = sprintf('application/json; charset=%s', $charset);
+		parent::__construct($code, $headers, $json, $version, $reasonPhrase);
 	}
 
     /**
+     * Returns the raw JSON string
+     *
      * @return string
      */
     public function getJson():string
@@ -77,10 +75,13 @@ class JsonResponse extends Response
     }
 
     /**
+     * Returns the decoded JSON string.
+     *
+     * @uses json_decode()
      * @return array
      * @throws ResponseException
      */
-    public function getJsonAsArray():array
+    public function getDecodedJson():array
     {
         if (!($array = json_decode($this->json, true))) {
             throw new ResponseException("Unable to decode the response's JSON", $this);
@@ -89,9 +90,10 @@ class JsonResponse extends Response
     }
 
     /**
-     * @return null|string
+     * @inheritdoc
+     * @return string
      */
-    public function getCharset():?string
+    public function getCharset():string
     {
         return $this->charset;
     }

--- a/src/LocalFileResponse.php
+++ b/src/LocalFileResponse.php
@@ -30,6 +30,9 @@ use CodeInc\Psr7Responses\Tests\LocalFileResponseTest;
  * @see LocalFileResponseTest
  * @package CodeInc\Psr7Responses
  * @author Joan Fabrégat <joan@codeinc.fr>
+ * @license MIT <https://github.com/CodeIncHQ/Psr7Responses/blob/master/LICENSE>
+ * @link https://github.com/CodeIncHQ/Psr7Responses
+ * @version 2
  */
 class LocalFileResponse extends FileResponse
 {
@@ -37,29 +40,28 @@ class LocalFileResponse extends FileResponse
      * LocalFileResponse constructor.
      *
      * @param string $filePath Local file path
+     * @param int $code
+     * @param string $reasonPhrase
      * @param null|string $fileName File's name (determined from the local file path if not specified)
      * @param null|string $contentType File's content type (determined from the file's name if not specified)
      * @param bool $asAttachment Defines if the file should be sent as an attachment
-     * @param int $status
      * @param array $headers
      * @param string $version
-     * @param null|string $reason
-     * @throws ResponseException
      * @throws \CodeInc\MediaTypes\Exceptions\MediaTypesException
      */
-	public function __construct(string $filePath, ?string $fileName = null, ?string $contentType = null,
-		bool $asAttachment = true, int $status = 200, array $headers = [],
-		string $version = '1.1', ?string $reason = null)
+	public function __construct(string $filePath,  int $code = 200, string $reasonPhrase = '',
+        ?string $fileName = null, ?string $contentType = null, bool $asAttachment = true,
+        array $headers = [], string $version = '1.1')
 	{
 		parent::__construct(
 			$filePath,
 			$fileName ?? basename($filePath),
+            $code,
+            $reasonPhrase,
 			$contentType,
 			$asAttachment,
-			$status,
             $headers,
-            $version,
-            $reason
+            $version
 		);
 	}
 }

--- a/src/NotFoundResponse.php
+++ b/src/NotFoundResponse.php
@@ -30,22 +30,30 @@ namespace CodeInc\Psr7Responses;
  * @author Joan Fabrégat <joan@codeinc.fr>
  * @license MIT <https://github.com/CodeIncHQ/Psr7Responses/blob/master/LICENSE>
  * @link https://github.com/CodeIncHQ/Psr7Responses
+ * @version 2
  */
 class NotFoundResponse extends HtmlResponse
 {
-	/**
-	 * NotFoundResponse constructor.
-	 *
-	 * @param string|null $html
-	 * @param null|string $charset
-	 * @param array $headers
-	 * @param null $body
-	 * @param string $version
-	 * @param null|string $reason
-	 */
-	public function __construct(string $html = null, ?string $charset = null, array $headers = [],
-		$body = null, string $version = '1.1', ?string $reason = null)
+    /**
+     * NotFoundResponse constructor.
+     *
+     * @param string|null $html
+     * @param int $code
+     * @param string $reasonPhrase
+     * @param string $charset
+     * @param array $headers
+     * @param string $version
+     */
+	public function __construct(string $html = null, int $code = 404, string $reasonPhrase = '',
+        string $charset = 'utf-8', array $headers = [], string $version = '1.1')
 	{
-		parent::__construct($html ?? '', $charset, 404, $headers, $version, $reason);
+		parent::__construct(
+		    $html ?? '',
+            $code,
+            $reasonPhrase,
+            $charset,
+            $headers,
+            $version
+        );
 	}
 }

--- a/src/RedirectResponse.php
+++ b/src/RedirectResponse.php
@@ -31,6 +31,7 @@ use GuzzleHttp\Psr7\Response;
  * @author Joan Fabrégat <joan@codeinc.fr>
  * @license MIT <https://github.com/CodeIncHQ/Psr7Responses/blob/master/LICENSE>
  * @link https://github.com/CodeIncHQ/Psr7Responses
+ * @version 2
  */
 class RedirectResponse extends Response
 {
@@ -39,22 +40,21 @@ class RedirectResponse extends Response
      */
     private $url;
 
-	/**
-	 * RedirectResponse constructor.
-	 *
-	 * @param string $url
-	 * @param int $status
-	 * @param array $headers
-	 * @param null $body
-	 * @param string $version
-	 * @param null|string $reason
-	 */
-	public function __construct(string $url, int $status = 302, array $headers = [],
-		$body = null, string $version = '1.1', ?string $reason = null)
+    /**
+     * RedirectResponse constructor.
+     *
+     * @param string $url
+     * @param int $code
+     * @param string $reasonPhrase
+     * @param array $headers
+     * @param string $version
+     */
+	public function __construct(string $url, int $code = 302, string $reasonPhrase = '',
+        array $headers = [], string $version = '1.1')
 	{
 	    $this->url = $url;
 		$headers["Location"] = $url;
-		parent::__construct($status, $headers, $body, $version, $reason);
+		parent::__construct($code, $headers, $version, $reasonPhrase);
 	}
 
     /**

--- a/src/StreamResponse.php
+++ b/src/StreamResponse.php
@@ -33,6 +33,7 @@ use Psr\Http\Message\StreamInterface;
  * @author Joan Fabrégat <joan@codeinc.fr>
  * @license MIT <https://github.com/CodeIncHQ/Psr7Responses/blob/master/LICENSE>
  * @link https://github.com/CodeIncHQ/Psr7Responses
+ * @version 2
  */
 class StreamResponse extends Response
 {
@@ -44,7 +45,7 @@ class StreamResponse extends Response
     /**
      * @var null|string
      */
-    private $charset;
+    private $contentType;
 
     /**
      * @var int|null
@@ -66,21 +67,21 @@ class StreamResponse extends Response
      *
      * @uses stream_for()
      * @param resource|string|null|int|float|bool|StreamInterface|callable $dataSource
+     * @param int $code
+     * @param string $reasonPhrase
      * @param null|string $contentType
      * @param int|null $contentLength
      * @param null|string $fileName
      * @param bool $asAttachment
-     * @param int $status
      * @param array $headers
      * @param string $version
-     * @param null|string $reason
      */
-	public function __construct($dataSource, ?string $contentType = null, ?int $contentLength = null,
-		?string $fileName = null, bool $asAttachment = false, int $status = 200, array $headers = [],
-		string $version = '1.1', ?string $reason = null)
+	public function __construct($dataSource, int $code = 200, string $reasonPhrase = '',
+        ?string $contentType = null, ?int $contentLength = null, ?string $fileName = null,
+        bool $asAttachment = false, array $headers = [], string $version = '1.1')
 	{
 		$this->stream = stream_for($dataSource);
-        $this->charset = $contentType;
+        $this->contentType = $contentType;
         $this->contentLength = $contentLength;
         $this->fileName = $fileName;
         $this->asAttachment = $asAttachment;
@@ -97,7 +98,7 @@ class StreamResponse extends Response
 			$headers["Content-Length"] = $contentLength;
 		}
 
-		parent::__construct($status, $headers, $this->stream, $version, $reason);
+		parent::__construct($code, $headers, $this->stream, $version, $reasonPhrase);
 	}
 
     /**
@@ -111,17 +112,17 @@ class StreamResponse extends Response
     }
 
     /**
-     * Returns the mime type if set or null.
+     * Returns the response's content type or NULL if not set.
      *
      * @return null|string
      */
-    public function getCharset():?string
+    public function getContentType():?string
     {
-        return $this->charset;
+        return $this->contentType;
     }
 
     /**
-     * Returns the content length if set or null.
+     * Returns the response's content's length or NULL if not set.
      *
      * @return int|null
      */
@@ -131,7 +132,7 @@ class StreamResponse extends Response
     }
 
     /**
-     * Returns the file name if set or null.
+     * Returns the response's filename or NULL if not set.
      *
      * @return null|string
      */
@@ -141,7 +142,7 @@ class StreamResponse extends Response
     }
 
     /**
-     * Verify if the response must be downloaded.
+     * Verify if the response must be treated as an attachment.
      *
      * @return bool
      */

--- a/src/TextResponse.php
+++ b/src/TextResponse.php
@@ -31,38 +31,36 @@ use GuzzleHttp\Psr7\Response;
  * @author Joan Fabrégat <joan@codeinc.fr>
  * @license MIT <https://github.com/CodeIncHQ/Psr7Responses/blob/master/LICENSE>
  * @link https://github.com/CodeIncHQ/Psr7Responses
+ * @version 2
  */
-class TextResponse extends Response
+class TextResponse extends Response implements CharsetResponseInterface
 {
-	public const DEFAULT_CHARSET = "utf-8";
-
     /**
      * @var string
      */
 	private $text;
 
     /**
-     * @var null|string
+     * @var string
      */
 	private $charset;
 
-	/**
-	 * TextResponse constructor.
-	 *
-	 * @param string $text
-	 * @param string|null $charset
-	 * @param int $status
-	 * @param array $headers
-	 * @param string $version
-	 * @param null|string $reason
-	 */
-	public function __construct(string $text, ?string $charset = null, int $status = 200, array $headers = [],
-		string $version = '1.1', ?string $reason = null)
+    /**
+     * TextResponse constructor.
+     *
+     * @param string $text
+     * @param int $code
+     * @param string $reasonPhrase
+     * @param string $charset
+     * @param array $headers
+     * @param string $version
+     */
+	public function __construct(string $text, int $code = 200, string $reasonPhrase = '',
+        string $charset = 'utf-8', array $headers = [], string $version = '1.1')
 	{
-	    $this->text = $text;
 	    $this->charset = $charset;
-		$headers["Content-Type"] = "text/plain; charset=".($charset ?? self::DEFAULT_CHARSET);
-		parent::__construct($status, $headers, $text, $version, $reason);
+		$headers['Content-Type'] = sprintf('text/plain; charset=%s', $charset);
+		parent::__construct($code, $headers, $text, $version, $reasonPhrase);
 	}
 
     /**
@@ -74,9 +72,10 @@ class TextResponse extends Response
     }
 
     /**
-     * @return null|string
+     * @inheritdoc
+     * @return string
      */
-    public function getCharset():?string
+    public function getCharset():string
     {
         return $this->charset;
     }

--- a/src/UnauthorizedResponse.php
+++ b/src/UnauthorizedResponse.php
@@ -29,6 +29,7 @@ namespace CodeInc\Psr7Responses;
  * @author Joan Fabrégat <joan@codeinc.fr>
  * @license MIT <https://github.com/CodeIncHQ/Psr7Responses/blob/master/LICENSE>
  * @link https://github.com/CodeIncHQ/Psr7Responses
+ * @version 2
  */
 class UnauthorizedResponse extends HtmlResponse
 {
@@ -36,15 +37,15 @@ class UnauthorizedResponse extends HtmlResponse
      * UnauthorizedResponse constructor.
      *
      * @param string|null $html
-     * @param null|string $charset
+     * @param int $code
+     * @param string $reasonPhrase
+     * @param string $charset
      * @param array $headers
-     * @param null $body
      * @param string $version
-     * @param null|string $reason
      */
-	public function __construct(string $html = null, ?string $charset = null, array $headers = [],
-		$body = null, string $version = '1.1', ?string $reason = null)
+	public function __construct(string $html = '', int $code = 401, string $reasonPhrase = '',
+        string $charset = 'utf-8', array $headers = [], string $version = '1.1')
 	{
-		parent::__construct($html ?? '', $charset, 401, $headers, $version, $reason);
+		parent::__construct($html, $code, $reasonPhrase, $charset, $headers, $version);
 	}
 }

--- a/src/XmlResponse.php
+++ b/src/XmlResponse.php
@@ -31,38 +31,37 @@ use GuzzleHttp\Psr7\Response;
  * @author Joan Fabrégat <joan@codeinc.fr>
  * @license MIT <https://github.com/CodeIncHQ/Psr7Responses/blob/master/LICENSE>
  * @link https://github.com/CodeIncHQ/Psr7Responses
+ * @version 2
  */
-class XmlResponse extends Response
+class XmlResponse extends Response implements CharsetResponseInterface
 {
-	public const DEFAULT_CHARSET = "utf-8";
-
     /**
      * @var string
      */
 	private $xml;
 
     /**
-     * @var null|string
+     * @var string
      */
 	private $charset;
 
-	/**
-	 * TextResponse constructor.
-	 *
-	 * @param string $xml
-	 * @param string|null $charset
-	 * @param int $status
-	 * @param array $headers
-	 * @param string $version
-	 * @param null|string $reason
-	 */
-	public function __construct(string $xml, ?string $charset = null, int $status = 200, array $headers = [],
-		string $version = '1.1', ?string $reason = null)
+    /**
+     * TextResponse constructor.
+     *
+     * @param string $xml
+     * @param int $code
+     * @param string $reasonPhrase
+     * @param string $charset
+     * @param array $headers
+     * @param string $version
+     */
+	public function __construct(string $xml, int $code = 200, string $reasonPhrase = '',
+        string $charset = 'utf-8', array $headers = [], string $version = '1.1')
 	{
 	    $this->xml = $xml;
 	    $this->charset = $charset;
-		$headers["Content-Type"] = "application/xml; charset=".($charset ?? self::DEFAULT_CHARSET);
-		parent::__construct($status, $headers, $xml, $version, $reason);
+		$headers['Content-Type'] = sprintf('application/xml; charset=%s', $charset);
+		parent::__construct($code, $headers, $xml, $version, $reasonPhrase);
 	}
 
     /**
@@ -74,9 +73,10 @@ class XmlResponse extends Response
     }
 
     /**
-     * @return null|string
+     * @inheritdoc
+     * @return string
      */
-    public function getCharset():?string
+    public function getCharset():string
     {
         return $this->charset;
     }


### PR DESCRIPTION
This version is optimized for [PSR-17 HTTP factories](https://www.php-fig.org/psr/psr-17/). The HTTP status code `$code` and reason phrase `$reasonPhrase` parameters of all responses have been moved to be the first optional parameters of all responses. 